### PR TITLE
Revert inputDim and batchSize

### DIFF
--- a/src/ReLULayer.cpp
+++ b/src/ReLULayer.cpp
@@ -6,7 +6,7 @@ using namespace std;
 
 ReLULayer::ReLULayer(ReLUConfig* conf, int _layerNum)
 :Layer(_layerNum),
- conf(conf->batchSize, conf->inputDim),
+ conf(conf->inputDim, conf->batchSize),
  activations(conf->batchSize * conf->inputDim), 
  deltas(conf->batchSize * conf->inputDim),
  reluPrime(conf->batchSize * conf->inputDim)


### PR DESCRIPTION
The order of inputDim and batchSize is defined in ReLUCOnfig as follows. We should preserve the order when using it.  :) 

```cpp
class ReLUConfig : public LayerConfig
{
public:
	size_t inputDim = 0;
	size_t batchSize = 0;

	ReLUConfig(size_t _inputDim, size_t _batchSize)
	:inputDim(_inputDim),
	 batchSize(_batchSize), 
	 LayerConfig("ReLU")
	{};
};
```
