### PR TITLE
Fixing floatToMyType

### DIFF
--- a/src/globals.h
+++ b/src/globals.h
@@ -14,7 +14,7 @@
 #define _aligned_malloc(size,alignment) aligned_alloc(alignment,size)
 #define _aligned_free free
 #define getrandom(min, max) ((rand()%(int)(((max) + 1)-(min)))+ (min))
-#define floatToMyType(a) ((myType)(a * (1 << FLOAT_PRECISION)))
+#define floatToMyType(a) ((myType)(int)floor(a * (1 << FLOAT_PRECISION)))
 
 
 /********************* AES and other globals *********************/


### PR DESCRIPTION
The previous implementation has the following bug: when the input is a float type and is negative, the output would be zero. E.g.,

`floatToMyType(-2.2)`

returns 0, which is not intended behavior.